### PR TITLE
only enable amplifier when needed

### DIFF
--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -655,6 +655,7 @@ void Base::handleReadCard() {
 
 void Idle::entry() {
   LOG(state_log, s_info, str_enter(), str_Idle());
+  tonuino.disableAmplifier();
   tonuino.setStandbyTimer();
 }
 
@@ -707,6 +708,7 @@ void Idle::react(card_e const &c_e) {
 
 void Play::entry() {
   LOG(state_log, s_info, str_enter(), str_Play());
+  tonuino.enableAmplifier();
   tonuino.disableStandbyTimer();
   mp3.start();
 }
@@ -789,6 +791,7 @@ void Play::react(card_e const &c_e) {
 
 void Pause::entry() {
   LOG(state_log, s_info, str_enter(), str_Pause());
+  tonuino.disableAmplifier();
   tonuino.setStandbyTimer();
   mp3.pause();
 }
@@ -851,6 +854,7 @@ void Pause::react(card_e const &c_e) {
 // #######################################################
 
 void StartPlay::entry() {
+  tonuino.enableAmplifier();
   LOG(state_log, s_info, str_enter(), str_StartPlay());
   mp3.enqueueMp3FolderTrack(mp3Tracks::t_262_pling);
 }
@@ -894,6 +898,7 @@ bool Amin_BaseWriteCard::handleWriteCard(command_e const &cmd_e, bool return_to_
 
 void Admin_Allow::entry() {
   LOG(state_log, s_info, str_enter(), str_Admin_Allow());
+  tonuino.enableAmplifier();
   current_subState = select_method;
   tonuino.resetActiveModifier();
 }
@@ -1009,6 +1014,7 @@ void Admin_Allow::react(command_e const &cmd_e) {
 
 void Admin_Entry::entry() {
   LOG(state_log, s_info, str_enter(), str_Admin_Entry());
+  tonuino.enableAmplifier();
   tonuino.disableStandbyTimer();
   tonuino.resetActiveModifier();
 
@@ -1107,6 +1113,7 @@ void Admin_Entry::react(command_e const &cmd_e) {
 // #######################################################
 
 void Admin_NewCard::entry() {
+  tonuino.enableAmplifier();
   LOG(state_log, s_info, str_enter(), str_Admin_NewCard());
   current_subState = start_setupCard;
 }

--- a/src/tonuino.cpp
+++ b/src/tonuino.cpp
@@ -24,7 +24,7 @@ void Tonuino::setup() {
 
 #if defined ALLinONE || defined ALLinONE_Plus
   pinMode(ampEnablePin, OUTPUT);
-  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::inactive));
+  disableAmplifier();
 
   pinMode(usbAccessPin, OUTPUT);
   digitalWrite(usbAccessPin, getLevel(usbAccessPinType, level::inactive));
@@ -50,9 +50,6 @@ void Tonuino::setup() {
   }
 
   SM_tonuino::start();
-#if defined ALLinONE || defined ALLinONE_Plus
-  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::active));
-#endif
 
   // Start Shortcut "at Startup" - e.g. Welcome Sound
   SM_tonuino::dispatch(command_e(commandRaw::start));
@@ -195,9 +192,22 @@ void Tonuino::disableStandbyTimer() {
   }
 }
 
+void Tonuino::enableAmplifier() {
+#if defined ALLinONE || defined ALLinONE_Plus
+  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::active));
+#endif
+}
+
+void Tonuino::disableAmplifier() {
+#if defined ALLinONE || defined ALLinONE_Plus
+  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::inactive));
+#endif
+}
+
 void Tonuino::checkStandby() {
   if (standbyTimer.isActive() && standbyTimer.isExpired()) {
     LOG(standby_log, s_info, F("power off!"));
+    disableAmplifier();
     // enter sleep state
     digitalWrite(shutdownPin, getLevel(shutdownPinType, level::inactive));
     delay(500);

--- a/src/tonuino.cpp
+++ b/src/tonuino.cpp
@@ -24,7 +24,7 @@ void Tonuino::setup() {
 
 #if defined ALLinONE || defined ALLinONE_Plus
   pinMode(ampEnablePin, OUTPUT);
-  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::active));
+  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::inactive));
 
   pinMode(usbAccessPin, OUTPUT);
   digitalWrite(usbAccessPin, getLevel(usbAccessPinType, level::inactive));
@@ -50,6 +50,10 @@ void Tonuino::setup() {
   }
 
   SM_tonuino::start();
+#if defined ALLinONE || defined ALLinONE_Plus
+  digitalWrite(ampEnablePin, getLevel(ampEnablePinType, level::active));
+#endif
+
   // Start Shortcut "at Startup" - e.g. Welcome Sound
   SM_tonuino::dispatch(command_e(commandRaw::start));
 }

--- a/src/tonuino.hpp
+++ b/src/tonuino.hpp
@@ -29,6 +29,9 @@ public:
   void setStandbyTimer();
   void disableStandbyTimer();
 
+  void enableAmplifier();
+  void disableAmplifier();
+
   void setCard  (const nfcTagObject   &newCard) { myCard = newCard; setFolder(&myCard.nfcFolderSettings); }
   const nfcTagObject& getCard() const           { return myCard; }
   void setFolder(folderSettings *newFolder    ) { myFolder = newFolder; }


### PR DESCRIPTION
depends on #22

This should save some power and suppress some noise from the mp3 chip.
The downside is a slight popping sound when the AMP is toggled. I wonder if we can get rid of that too.