### PR TITLE
Issue 026: : DFMiniMp3 lib support T_CHIP_VARIANT

### DIFF
--- a/Tonuino.ino
+++ b/Tonuino.ino
@@ -19,10 +19,8 @@
 
 /*
 Please select your TonUINO PCB (Classic, AiO or AiO+) in file constants.hpp
-Right now you must use an older version of the DFPlayer Mini Mp3 by Makuna library (1.0.7)!
 
 Bitte wählt eure TonUINO-Platine (Classic, AiO oder AiO+) in der Datei constands.hpp
-Aktuell wird nur eine ältere Version der DFPlayer Mini Mp3 by Makuna Bibliothek (1.0.7) unterstützt!
 */
 
 void setup()

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -22,7 +22,7 @@
 
 // uncomment the below line to support the MH2024K16SS chip on the DfMiniMp3 player
 // um den Chip MH2024K16SS auf dem DfMiniMp3 Player zu ünterstützen bitte in der nächste Zeile den Kommentar entfernen
-#define DFMiniMp3_T_CHIP_VARIANT Mp3ChipMH2024K16SS
+//#define DFMiniMp3_T_CHIP_VARIANT Mp3ChipMH2024K16SS
 
 // ####### helper for level ############################
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -20,6 +20,10 @@
 // 4: allLong    5: pause      6: pauseLong
 // 1:            2: down       3: downLong
 
+// uncomment the below line to support the MH2024K16SS chip on the DfMiniMp3 player
+// um den Chip MH2024K16SS auf dem DfMiniMp3 Player zu ünterstützen bitte in der nächste Zeile den Kommentar entfernen
+#define DFMiniMp3_T_CHIP_VARIANT Mp3ChipMH2024K16SS
+
 // ####### helper for level ############################
 
 enum class level : uint8_t {

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -10,7 +10,7 @@ DEFINE_LOGGER(card_log    , s_info   , tonuino_log);
 DEFINE_LOGGER(play_log    , s_warning, tonuino_log);
 DEFINE_LOGGER(standby_log , s_warning, tonuino_log);
 DEFINE_LOGGER(state_log   , s_info   , tonuino_log);
-DEFINE_LOGGER(button_log  , s_info   , tonuino_log);
+DEFINE_LOGGER(button_log  , s_debug   , tonuino_log);
 DEFINE_LOGGER(modifier_log, s_warning, tonuino_log);
 DEFINE_LOGGER(mp3_log     , s_info   , tonuino_log);
 DEFINE_LOGGER(settings_log, s_info   , tonuino_log);

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -10,7 +10,7 @@ DEFINE_LOGGER(card_log    , s_info   , tonuino_log);
 DEFINE_LOGGER(play_log    , s_warning, tonuino_log);
 DEFINE_LOGGER(standby_log , s_warning, tonuino_log);
 DEFINE_LOGGER(state_log   , s_info   , tonuino_log);
-DEFINE_LOGGER(button_log  , s_debug   , tonuino_log);
+DEFINE_LOGGER(button_log  , s_info   , tonuino_log);
 DEFINE_LOGGER(modifier_log, s_warning, tonuino_log);
 DEFINE_LOGGER(mp3_log     , s_info   , tonuino_log);
 DEFINE_LOGGER(settings_log, s_info   , tonuino_log);

--- a/src/mp3.hpp
+++ b/src/mp3.hpp
@@ -23,8 +23,11 @@ using SerialType = HardwareSerial;
 class Mp3Notify;
 
 // define a handy type using serial and our notify class
+#ifdef DFMiniMp3_T_CHIP_VARIANT
+using DfMp3 = DFMiniMp3<SerialType, Mp3Notify, DFMiniMp3_T_CHIP_VARIANT>;
+#else
 using DfMp3 = DFMiniMp3<SerialType, Mp3Notify>;
-
+#endif
 
 enum class mp3Tracks: uint16_t {
   t_0                          =   0,


### PR DESCRIPTION
You can select the MH2024K16SS chip of the DfMiniMp3 player by editing the constants.hpp or by adding 
`-D DFMiniMp3_T_CHIP_VARIANT=Mp3ChipMH2024K16SS`
to the command line of the compiler
Also removed the obsolete comment about version if the DFMiniMp3 library (resolves issue #25)