### PR TITLE
Issue_039: No pause if card is removed too early

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Die SD Karte (Ordner mp3 und advert) hat sich gegenüber der Version 2.x geände
 
 # Change Log
 
+## Version 3.1.2 (20.01.2023)
+- [Issue 039](https://github.com/tonuino/TonUINO-TNG/issues/39): No pause if card is removed too early
+
 ## Version 3.1.2 (16.01.2023)
 - [Issue 028](https://github.com/tonuino/TonUINO-TNG/issues/28): Revise Button behavior
 

--- a/TonUINO-TNG.ino
+++ b/TonUINO-TNG.ino
@@ -35,7 +35,7 @@ void setup()
   LOG(init_log, s_error, F("TonUINO Version 3.1 - refactored by Boerge1\n"));
   LOG(init_log, s_error, F("created by Thorsten Voß and licensed under GNU/GPL."));
   LOG(init_log, s_error, F("Information and contribution at https://tonuino.de.\n"));
-  LOG(init_log, s_error, F("V3.1.2 16.01.23\n"));
+  LOG(init_log, s_error, F("V3.1.2 20.01.23\n"));
 
   Tonuino::getTonuino().setup();
 }

--- a/src/chip_card.hpp
+++ b/src/chip_card.hpp
@@ -45,7 +45,7 @@ struct folderSettings {
     if (mode == pmode_t::einzel && special != rhs.special)
       return false;
     if ((mode == pmode_t::hoerspiel_vb || mode == pmode_t::album_vb || mode == pmode_t::party_vb) &&
-        (special != rhs.special || special2 == rhs.special2))
+        (special != rhs.special || special2 != rhs.special2))
       return false;
     return true;
   }

--- a/src/mp3.hpp
+++ b/src/mp3.hpp
@@ -189,6 +189,7 @@ public:
   void loop          ();
 
 private:
+  friend class tonuino_test_fixture;
 
   typedef queue<uint8_t, maxTracksInFolder> track_queue;
 

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -639,7 +639,10 @@ void StartPlay::react(command_e const &/*cmd_e*/) {
   if (not mp3.isPlayingMp3()) {
     tonuino.playFolder();
     LOG(state_log, s_debug, str_StartPlay(), str_to(), str_Play());
-    transit<Play>();
+    if (settings.pauseWhenCardRemoved && chip_card.isCardRemoved())
+      transit<Pause>();
+    else
+      transit<Play>();
   }
 }
 


### PR DESCRIPTION
* fix state machine (after StartPlay goto Pause if card is removed)
* implement unit tests for 'pause if card is removed' feature
* fix bug: 'pause if card is removed' not working for 'von bis'