### PR TITLE
TTS Script improvements

### DIFF
--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -103,7 +103,7 @@ def addLeadInMessage(inputPath, outputPath):
 def detectAudioData(mp3File):
     try:
         output = subprocess.check_output([ 'ffmpeg', '-i', mp3File, '-hide_banner' ], stderr=subprocess.STDOUT)
-    except Exception, e:
+    except Exception as e:
         output = str(e.output)
 
     match = re.match('.*Stream #\\d+:\\d+: Audio: mp3, (\\d+) Hz, (mono|stereo), .*', output, re.S)

--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -74,6 +74,9 @@ def addLeadInMessage(inputPath, outputPath):
         return
 
     text = re.sub(fileRegex, titlePattern, inputFileName).replace('_', ' ').strip()
+    if text == '':
+        print('File {} does not have a title. Skipping.'.format(outputPath))
+        return
     print('Adding lead-in "{}" to {}'.format(text, os.path.abspath(outputPath)))
 
     if not args.dry_run:

--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Adds a lead-in message to each mp3 file of a directory storing the result in another directory.
 # So - when played e.g. on a TonUINO - you first will hear the title of the track, then the track itself.

--- a/tools/create_audio_messages.py
+++ b/tools/create_audio_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Creates the audio messages needed by TonUINO.
 

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -113,11 +113,6 @@ def postJson(url, postBody, headers = None):
     return json.loads(response)
 
 
-def postForm(url, formData):
-    response = subprocess.check_output(['curl', '-H', 'Content-Type: application/x-www-form-urlencoded; charset=utf-8', '--data', urllib.urlencode(formData), url])
-    return json.loads(response)
-
-
 if __name__ == '__main__':
     argFormatter = lambda prog: argparse.RawDescriptionHelpFormatter(prog, max_help_position=30, width=100)
     argparser = PatchedArgumentParser(

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -8,7 +8,7 @@ import argparse, base64, json, os, subprocess, sys, urllib.request
 
 class PatchedArgumentParser(argparse.ArgumentParser):
     def error(self, message):
-        sys.stderr.write('error: %s\n\n' % message)
+        sys.stderr.write('ERROR: %s\n\n' % message)
         self.print_help()
         sys.exit(2)
 

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -16,15 +16,18 @@ class PatchedArgumentParser(argparse.ArgumentParser):
 sayVoiceByLang = {
     'de': 'Anna',
     'en': 'Samantha',
+    'fr': 'Thomas',
 }
 googleVoiceByLang = {
     'de': { 'languageCode': 'de-DE', 'name': 'de-DE-Wavenet-C' },
     'en': { 'languageCode': 'en-US', 'name': 'en-US-Wavenet-D' },
+    'fr': { 'languageCode': 'fr-FR', 'name': 'fr-FR-Neural2-A' },
 }
 amazonVoiceByLang = {
     # See: https://docs.aws.amazon.com/de_de/polly/latest/dg/voicelist.html
     'de': 'Vicki',
     'en': 'Joanna',
+    'fr': 'Léa',
 }
 
 

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -52,7 +52,15 @@ def checkArgs(argparser, args):
         print('ERROR: You have to provide one of the arguments `--use-say`, `--use-amazon` or `--use-google-key`\n')
         argparser.print_help()
         sys.exit(2)
-
+    if args.use_say and args.lang not in sayVoiceByLang:
+        print('ERROR: Language is not configured for the "say" text-to-speech engine.\n')
+        sys.exit(2)
+    if args.use_google_key and args.lang not in googleVoiceByLang:
+        print('ERROR: Language is not configured for the "say" text-to-speech engine.\n')
+        sys.exit(2)
+    if args.use_amazon and args.lang not in amazonVoiceByLang:
+        print('ERROR: Language is not configured for the "say" text-to-speech engine.\n')
+        sys.exit(2)
 
 def textToSpeechUsingArgs(text, targetFile, args):
     textToSpeech(text, targetFile, lang=args.lang, useAmazon=args.use_amazon, useGoogleKey=args.use_google_key)

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -38,7 +38,10 @@ Amazon Polly sounds best, Google text-to-speech is second, MacOS `say` sounds wo
 """.strip()
 
 def addArgumentsToArgparser(argparser):
-    argparser.add_argument('--lang', choices=['de', 'en'], default='de', help='The language (default: de)')
+    # Create a list of supported languages directly from the say/Amazon/Google service configurations
+    supported_languages = list({key for d in [sayVoiceByLang, googleVoiceByLang, amazonVoiceByLang] for key in d.keys()})
+
+    argparser.add_argument('--lang', choices=supported_languages, default='de', help='The language (default: de)')
     argparser.add_argument('--use-say', action='store_true', default=None, help="If set, the MacOS tool `say` will be used.")
     argparser.add_argument('--use-amazon', action='store_true', default=None, help="If set, Amazon Polly is used. If missing the MacOS tool `say` will be used.")
     argparser.add_argument('--use-google-key', type=str, default=None, help="The API key of the Google text-to-speech account to use.")

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Converts text into spoken language saved to an mp3 file.
 

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -3,7 +3,7 @@
 # Converts text into spoken language saved to an mp3 file.
 
 
-import argparse, base64, json, os, subprocess, sys, urllib
+import argparse, base64, json, os, subprocess, sys, urllib.request
 
 
 class PatchedArgumentParser(argparse.ArgumentParser):
@@ -104,13 +104,18 @@ def textToSpeech(text, targetFile, lang='de', useAmazon=False, useGoogleKey=None
 
 
 def postJson(url, postBody, headers = None):
-    cmd = ['curl']
-    if headers is not None:
-        for header in headers:
-            cmd.extend(['-H', header])
-    cmd.extend(['-H', 'Content-Type: application/json; charset=utf-8', '--data', json.dumps(postBody).encode('utf-8'), url])
-    response = subprocess.check_output(cmd)
-    return json.loads(response)
+    if headers is None:
+        headers = {}
+    headers['Content-Type'] = 'application/json; charset=utf-8'
+    data = json.dumps(postBody).encode('utf-8')
+    try:
+        request = urllib.request.Request(url, data, headers)
+        with urllib.request.urlopen(request) as req:
+            response_data=req.read()
+        return json.loads(response_data.decode())
+    except Exception as e:
+        print(e)
+        exit(2)
 
 
 if __name__ == '__main__':

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -65,7 +65,7 @@ def textToSpeech(text, targetFile, lang='de', useAmazon=False, useGoogleKey=None
             targetFile])
     elif useGoogleKey:
         responseJson = postJson(
-            'https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=' + useGoogleKey,
+            'https://texttospeech.googleapis.com/v1/text:synthesize?key=' + useGoogleKey,
             {
                 'audioConfig': {
                     'audioEncoding': 'MP3',


### PR DESCRIPTION
This PR is an alternative to #14 

Differences to #14: 

* I didn't change the way concatenation is done in add_lead_in_messages.py, as the current code worked for me.
* I've left in the --only-new argument in create_audio_messages.py (because I've used that all the time while translating). At the same time, I did not add the "exit(1)" if the folder already exists, because I've kept adding files to the existing directory each time I translated a new block.
* I didn't change the target directory (as that can be specified as an argument).
* I didn't add all the other languages, because I think translators should do that themselves. For French, I ended up using a different configuration than in #14, because the voice just didn't sound right.

Additional changes not in #14:

* The list of supported languages is generated automatically from the Google/Amazon/say configuration, so it doesn't have to be specified manually again.
* In add_lead_in_messages.py, skip a file if it doesn't have a title (previously, that resulted in an error).
* In add_lead_in_messages.py, try to get the title from the MP3 metadata. If that doesn't exist, fall back to the old method of extracting the title from the filename.

I've tested the code with Google TTS.