### PR TITLE
Error message when no PCB define was specified

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -82,7 +82,7 @@
 
 #include "gpioHelper.hpp"
 
-#if not defined(TonUINO_Classic) and not defined(TonUINO_Every) and not defined(TonUINO_Every_4808) and not defined(ALLinONE) and not defined(ALLinONE_Plus)
+#if not defined(TonUINO_Classic) and not defined(TonUINO_Every) and not defined(TonUINO_Every_4808) and not defined(ALLinONE) and not defined(ALLinONE_Plus) and not defined(TonUINO_Esp32)
 #error Please uncomment one of the PCB lines (TonUINO_Classic, TonUINO_Every, etc.). Bitte eine der Zeilen zur Definition einer Platine einkommentieren (TonUINO_Classic, TonUINO_Every, etc.).
 #endif
 


### PR DESCRIPTION
Hello,

when trying to compile the TonUINO code for the first time with Arduino Studio, I ran into several compile errors deep in the code. The reason for this was that I forgot to set a PCB define ("TonUINO_Classic" etc.), but it took me some time to figure out the problem. To make this easier for others, I added an error message if no PCB define is set.
This does not affect building with VS Code at least with the given build configurations as there the appropriate device define is set.
Furthermore, it may cause problems if a new PCB is added. I think, however, that this will show up immediately when trying to compile for the new PCB, so this shouldn't be too big of a problem.
If you think this is a helpful change, feel free to merge it or drop it otherwise.

Best regards